### PR TITLE
tamagotchi shape and layout

### DIFF
--- a/backed-community-nft.svg
+++ b/backed-community-nft.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 69 54" style="width: 690; height: 540; margin: 100px auto;" xml:space="preserve">
+	 viewBox="0 0 79 99" style="width: 474; height: 594; margin: 100px auto;" xml:space="preserve">
 
 <style type="text/css">
 	.checker{fill: #fff; opacity: 0.8;}
 	.background{fill: #EFEBE7; opacity: 0.4;}
-	.st1{font-family: monospace; font-size: 2.5px; letter-spacing: 0.2px;}
+	.st1{font-family: monospace; font-size: 2px; letter-spacing: 0.2px; text-anchor: end;}
 	.st2{font-family: monospace; font-size: 2px;}
 	.st3{font-family: monospace; font-size: 2px; text-anchor: middle;}
 	.empty{fill: #EFEBE7; opacity: 0.8;}
@@ -26,9 +26,8 @@
 	</g>
 	<g id="starrow" class="empty" width="21" height="3">
 		<use x="0" xlink:href="#star"/>
-		<use x="6" xlink:href="#star"/>
-		<use x="12" xlink:href="#star"/>
-		<use x="18" xlink:href="#star"/>
+		<use x="5" xlink:href="#star"/>
+		<use x="10" xlink:href="#star"/>
 	</g>	
 	<g id="earnedxp" width="3" height="3">
 		<use x="0" xlink:href="#star"/>
@@ -47,148 +46,203 @@
 		<rect class="starshine" x="0" y="0" width="1" height="1"><animate attributeName="opacity" values="0;.6;0" dur="4s" begin="0s" repeatCount="indefinite" /></rect>
 		<rect class="starshine" x="1" y="2" width="1" height="1"><animate attributeName="opacity" values="0;.8;0" dur="4s" begin="2s" repeatCount="indefinite" /></rect>
 		<rect class="starshine" x="7" y="0" width="1" height="1"><animate attributeName="opacity" values="0;.8;0" dur="4s" begin="3s" repeatCount="indefinite" /></rect>
-	
 	</g>	
+/* Define glow filter */
+	<filter id="glow" x="0" y="0" width="79" height="99" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+		<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+		<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+		<feGaussianBlur stdDeviation="6.5"/>
+		<feComposite in2="hardAlpha" operator="out"/>
+		<feColorMatrix type="matrix" values="0 0 0 0 0.509804 0 0 0 0 0.639216 0 0 0 0 0.368627 0 0 0 0.25 0"/>
+	</filter>
 </defs>
 
-/* Background and fill pattern*/
-<rect class="background" x="0" y="0" width="100%" height="100%"/>
-<pattern id="pixels" x="0" y="0" width="30" height="30" patternUnits="userSpaceOnUse" >
-	<rect class="checker" x="3" y="0" width="3" height="9"/>
-	<rect class="checker" x="0" y="3" width="9" height="3"/>
-	<rect class="checker" x="21" y="0" width="3" height="3"/>
-	<rect class="checker" x="0" y="15" width="3" height="3"/>
-	<rect class="checker" x="15" y="6" width="3" height="9"/>
-	<rect class="checker" x="12" y="9" width="9" height="3"/>
-	<rect class="checker" x="9" y="18" width="3" height="9"/>
-	<rect class="checker" x="6" y="21" width="9" height="3"/>
-	<rect class="checker" x="21" y="24" width="3" height="3"/>
-	<rect class="checker" x="18" y="27" width="9" height="3"/>
-	<rect class="checker" x="24" y="15" width="3" height="3"/>
-	<rect class="checker" x="27" y="12" width="9" height="9"/>
-</pattern>
-<rect x="-9" y="-9" width="120%" height="120%" fill="url(#pixels)" transform="translate(0 0)" opacity="0"> 
-	<animate attributeName="opacity" values="0;1;0;0" keyTimes="0;.15;.7;1" dur="10s" begin="0s" repeatCount="indefinite" /></rect>
-<rect x="-9" y="-9" width="120%" height="120%" fill="url(#pixels)" transform="translate(3 9)" opacity="0">
-	<animate attributeName="opacity" values="0;1;0;0" keyTimes="0;.15;.7;1" dur="10s" begin="5s" repeatCount="indefinite" /></rect>
-
-/* Stats */
-<g transform="translate(39 8)">
-	<text>
-		<tspan x="0" y="0" class="st1">ACTIVITY</tspan>
-		<tspan x="0" y="9" class="st1">CONTRIBUTOR</tspan>
-		<tspan x="0" y="18" class="st1">COMMUNITY</tspan>
-		<tspan x="0" y="28" class="st2">1 Community Call</tspan>
-		<tspan x="0" y="31" class="st2">2 Loans Received</tspan>
-		<tspan x="0" y="34" class="st2">6 Loans Given</tspan>
-		<tspan x="0" y="37" class="st2">0 Pull Requests</tspan>
-		<tspan x="0" y="40" class="st2">Joined Oct 19, 2022</tspan>
-	</text>
-
-	/* Activity */
-	<use x="0" y="2" xlink:href="#starrow"/>
-	<use x="0" y="2" xlink:href="#earnedxp" class="activity"/>
-	<use x="6" y="2" xlink:href="#earnedxp" class="activity"/>
-	<use x="12" y="2" xlink:href="#earnedxp" class="activity"/>
-
-	/* Contributor */
-	<use x="0" y="11" xlink:href="#counter" class="contributor"/>
-	<text x="10" y="13" class="st1">x7</text>
-
-	/* Community */
-	<use x="0" y="20" xlink:href="#starrow"/>
-	<use x="0" y="20" xlink:href="#earnedxp" class="community"/>
+/* Tamagotchi shape */
+<g filter="url(#glow)">
+<path d="M65.3113 48.4258C67.7592 76.1673 64.6664 86 39.7198 86C14.7733 86 11.0325 76.6593 13.7576 48.6718C16.4827 20.6842 20.0692 13 39.5346 13C59 13 62.8635 20.6842 65.3113 48.4258Z" fill="white"/>
 </g>
 
-<text class="st3">
-	<tspan x="20" y="45">Ox128a...175f</tspan>
-	<tspan x="20" y="48">Arbitrary Update Scarf</tspan>
-</text>
+/* Stats */
+<g transform="translate(41 58)">
+	<text><tspan x="-2" y="2" class="st1">ACTIVITY</tspan><tspan x="-2" y="8" class="st1">CONTRIBUTOR</tspan><tspan x="-2" y="14" class="st1">COMMUNITY</tspan></text>
+
+	/* Activity */
+	<use x="0" y="0" xlink:href="#starrow"/>
+	<use x="0" y="0" xlink:href="#earnedxp" class="activity"/>
+	<use x="5" y="0" xlink:href="#earnedxp" class="activity"/>
+	<use x="10" y="0" xlink:href="#earnedxp" class="activity"/>
+
+	/* Contributor */
+	<use x="0" y="6" xlink:href="#counter" class="contributor"/>
+	<text x="13" y="8" class="st1">x7</text>
+
+	/* Community */
+	<use x="0" y="12" xlink:href="#starrow"/>
+	<use x="0" y="12" xlink:href="#earnedxp" class="community"/>
+</g>
+
+<text class="st3"><tspan x="40" y="78	">Arbitrary Update Scarf</tspan><tspan x="40" y="81">0x128a...175f</tspan></text>
 
 /* Bunny PFP */
-<svg width="35" height="35" viewBox="0 0 35 35" fill="none" xmlns="http://www.w3.org/2000/svg" x="2" y="4" xml:space="preserve" shape-rendering="optimizeSpeed">
-<rect x="9" y="14" width="17" height="17" fill="black"/>
-<rect x="10" y="15" width="15" height="15" fill="white"/>
-<rect width="1" height="13" transform="matrix(-1 0 0 1 24 16)" fill="black"/>
-<rect width="1" height="13" transform="matrix(-1 0 0 1 12 16)" fill="black"/>
-<rect width="3" height="1" transform="matrix(-1 0 0 1 19 16)" fill="black"/>
-<rect x="4" y="8" width="1" height="4" fill="black"/>
-<rect x="14" y="8" width="1" height="2" fill="black"/>
-<rect x="22" y="2" width="1" height="2" fill="black"/>
-<rect x="18" y="8" width="1" height="4" fill="black"/>
-<rect x="17" y="4" width="1" height="4" fill="black"/>
-<rect x="23" y="4" width="1" height="3" fill="black"/>
-<rect x="24" y="7" width="1" height="3" fill="black"/>
-<rect x="23" y="10" width="1" height="4" fill="black"/>
-<rect x="11" y="13" width="1" height="2" fill="black"/>
-<rect x="12" y="15" width="1" height="2" fill="black"/>
-<rect x="22" y="14" width="1" height="3" fill="black"/>
-<rect x="15" y="10" width="1" height="7" fill="black"/>
-<rect x="19" y="12" width="1" height="5" fill="black"/>
-<rect x="5" y="7" width="1" height="1" fill="black"/>
-<rect x="12" y="6" width="1" height="1" fill="black"/>
-<rect x="13" y="7" width="1" height="1" fill="black"/>
-<rect x="18" y="2" width="1" height="2" fill="black"/>
-<rect x="12" y="9" width="1" height="1" fill="black"/>
-<rect x="10" y="12" width="1" height="1" fill="black"/>
-<rect x="6" y="6" width="3" height="1" fill="black"/>
-<rect x="5" y="12" width="3" height="1" fill="black"/>
-<rect x="10" y="10" width="2" height="1" fill="black"/>
-<rect x="8" y="11" width="3" height="1" fill="black"/>
-<rect x="9" y="5" width="3" height="1" fill="black"/>
-<rect x="9" y="6" width="3" height="1" fill="white"/>
-<rect x="19" y="2" width="3" height="2" fill="white"/>
-<rect x="18" y="4" width="5" height="3" fill="white"/>
-<rect x="18" y="7" width="6" height="1" fill="white"/>
-<rect x="19" y="8" width="5" height="2" fill="white"/>
-<rect x="19" y="10" width="4" height="2" fill="white"/>
-<rect x="20" y="12" width="3" height="2" fill="white"/>
-<rect x="20" y="14" width="2" height="3" fill="white"/>
-<rect x="12" y="10" width="3" height="1" fill="white"/>
-<rect x="11" y="11" width="4" height="2" fill="white"/>
-<rect x="12" y="13" width="3" height="2" fill="white"/>
-<rect x="13" y="15" width="2" height="2" fill="white"/>
-<rect x="5" y="11" width="3" height="1" fill="white"/>
-<rect x="6" y="7" width="7" height="1" fill="white"/>
-<rect x="5" y="8" width="9" height="1" fill="white"/>
-<rect x="13" y="9" width="1" height="1" fill="white"/>
-<rect x="5" y="9" width="7" height="1" fill="white"/>
-<rect x="5" y="10" width="5" height="1" fill="white"/>
-<rect x="19" y="1" width="3" height="1" fill="black"/>
-<rect width="11" height="1" transform="matrix(-1 0 0 1 23 28)" fill="black"/>
-<rect width="11" height="11" transform="matrix(-1 0 0 1 23 17)" fill="white"/>
-<rect x="14" y="20" width="1" height="1" fill="black"/>
-<rect x="20" y="20" width="1" height="1" fill="black"/>
-<rect x="13" y="21" width="1" height="1" fill="black"/>
-<rect x="15" y="21" width="1" height="1" fill="black"/>
-<rect x="19" y="21" width="1" height="1" fill="black"/>
-<rect x="21" y="21" width="1" height="1" fill="black"/>
-<rect x="16" y="24" width="3" height="1" fill="black"/>
-<rect x="17" y="25" width="1" height="1" fill="black"/>
+<svg width="39" height="39" viewBox="0 0 39 39" fill="none" xmlns="http://www.w3.org/2000/svg" x="20" y="20">
+<rect x="11" y="14" width="17" height="17" fill="black"/>
+<rect x="12" y="15" width="15" height="15" fill="white"/>
+<rect width="1" height="13" transform="matrix(-1 0 0 1 26 16)" fill="#010101"/>
+<rect width="1" height="13" transform="matrix(-1 0 0 1 14 16)" fill="#010101"/>
+<rect width="3" height="1" transform="matrix(-1 0 0 1 21 16)" fill="#010101"/>
+<rect x="6" y="8" width="1" height="4" fill="#010101"/>
+<rect x="16" y="8" width="1" height="2" fill="#010101"/>
+<rect x="24" y="2" width="1" height="2" fill="#010101"/>
+<rect x="20" y="8" width="1" height="4" fill="#010101"/>
+<rect x="19" y="4" width="1" height="4" fill="#010101"/>
+<rect x="25" y="4" width="1" height="3" fill="#010101"/>
+<rect x="26" y="7" width="1" height="3" fill="#010101"/>
+<rect x="25" y="10" width="1" height="4" fill="#010101"/>
+<rect x="13" y="13" width="1" height="2" fill="#010101"/>
+<rect x="14" y="15" width="1" height="2" fill="#010101"/>
+<rect x="24" y="14" width="1" height="3" fill="#010101"/>
+<rect x="17" y="10" width="1" height="7" fill="#010101"/>
+<rect x="21" y="12" width="1" height="5" fill="#010101"/>
+<rect x="7" y="7" width="1" height="1" fill="#010101"/>
+<rect x="14" y="6" width="1" height="1" fill="#010101"/>
+<rect x="15" y="7" width="1" height="1" fill="#010101"/>
+<rect x="20" y="2" width="1" height="2" fill="#010101"/>
+<rect x="14" y="9" width="1" height="1" fill="#010101"/>
+<rect x="12" y="12" width="1" height="1" fill="#010101"/>
+<rect x="8" y="6" width="3" height="1" fill="#010101"/>
+<rect x="7" y="12" width="3" height="1" fill="#010101"/>
+<rect x="12" y="10" width="2" height="1" fill="#010101"/>
+<rect x="10" y="11" width="3" height="1" fill="#010101"/>
+<rect x="11" y="5" width="3" height="1" fill="#010101"/>
+<rect x="11" y="6" width="3" height="1" fill="#FEFEFE"/>
+<rect x="21" y="2" width="3" height="2" fill="#FEFEFE"/>
+<rect x="20" y="4" width="5" height="3" fill="#FEFEFE"/>
+<rect x="20" y="7" width="6" height="1" fill="#FEFEFE"/>
+<rect x="21" y="8" width="5" height="2" fill="#FEFEFE"/>
+<rect x="21" y="10" width="4" height="2" fill="#FEFEFE"/>
+<rect x="22" y="12" width="3" height="2" fill="#FEFEFE"/>
+<rect x="22" y="14" width="2" height="3" fill="#FEFEFE"/>
+<rect x="14" y="10" width="3" height="1" fill="#FEFEFE"/>
+<rect x="13" y="11" width="4" height="2" fill="#FEFEFE"/>
+<rect x="14" y="13" width="3" height="2" fill="#FEFEFE"/>
+<rect x="15" y="15" width="2" height="2" fill="#FEFEFE"/>
+<rect x="7" y="11" width="3" height="1" fill="#FEFEFE"/>
+<rect x="8" y="7" width="7" height="1" fill="#FEFEFE"/>
+<rect x="7" y="8" width="9" height="1" fill="#FEFEFE"/>
+<rect x="15" y="9" width="1" height="1" fill="#FEFEFE"/>
+<rect x="7" y="9" width="7" height="1" fill="#FEFEFE"/>
+<rect x="7" y="10" width="5" height="1" fill="#FEFEFE"/>
+<rect x="21" y="1" width="3" height="1" fill="#010101"/>
+<rect width="11" height="1" transform="matrix(-1 0 0 1 25 28)" fill="#010101"/>
+<rect width="11" height="11" transform="matrix(-1 0 0 1 25 17)" fill="#FEFEFE"/>
+<rect x="16" y="20" width="1" height="1" fill="#010101"/>
+<rect x="22" y="20" width="1" height="1" fill="#010101"/>
+<rect x="15" y="21" width="1" height="1" fill="#010101"/>
+<rect x="17" y="21" width="1" height="1" fill="#010101"/>
+<rect x="21" y="21" width="1" height="1" fill="#010101"/>
+<rect x="23" y="21" width="1" height="1" fill="#010101"/>
+<rect x="18" y="24" width="3" height="1" fill="#010101"/>
+<rect x="19" y="25" width="1" height="1" fill="#010101"/>
 </svg>
 
+
 /* Special Trait */
-<svg width="39" height="39" viewBox="0 0 39 39" fill="none" x="2" y="5" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" shape-rendering="optimizeSpeed">
-<rect x="14" y="28" width="1" height="1" fill="#75B4FF"/>
-<rect x="15" y="29" width="1" height="1" fill="#75B4FF"/>
-<rect x="16" y="30" width="1" height="1" fill="#FFE5A1"/>
-<rect x="17" y="29" width="1" height="1" fill="#F8D270"/>
-<rect x="18" y="29" width="1" height="1" fill="#F8D270"/>
-<rect x="16" y="29" width="1" height="1" fill="#FFE5A2"/>
-<rect x="17" y="32" width="1" height="1" fill="#FFE5A2"/>
-<rect x="17" y="32" width="1" height="1" fill="#FFE5A2"/>
-<rect x="17" y="31" width="1" height="1" fill="#FFE5A2"/>
-<rect x="16" y="31" width="1" height="1" fill="#FFE5A2"/>
-<rect x="18" y="31" width="1" height="1" fill="#FFE5A2"/>
-<rect x="17" y="33" width="1" height="1" fill="#FFE5A2"/>
-<rect x="17" y="33" width="1" height="1" fill="#FFE5A2"/>
-<rect x="18" y="33" width="1" height="1" fill="#FFE5A2"/>
-<rect x="18" y="34" width="1" height="1" fill="#F8D270"/>
-<rect x="17" y="34" width="1" height="1" fill="#FFE5A2"/>
-<rect x="20" y="28" width="1" height="1" fill="#75B4FF"/>
-<rect x="19" y="29" width="1" height="1" fill="#75B4FF"/>
-<rect x="18" y="30" width="1" height="1" fill="#F8D270"/>
+<svg width="39" height="39" viewBox="0 0 39 39" fill="none" xmlns="http://www.w3.org/2000/svg" x="20" y="20">
+<rect x="29" y="23" width="1" height="1" fill="#82A35E"/>
+<rect x="30" y="23" width="1" height="1" fill="#82A35E"/>
+<rect x="12" y="24" width="1" height="1" fill="#82A35E"/>
+<rect x="28" y="24" width="1" height="1" fill="#82A35E"/>
+<rect x="29" y="24" width="1" height="1" fill="#344635"/>
+<rect x="30" y="24" width="1" height="1" fill="#82A35E"/>
+<rect x="31" y="24" width="1" height="1" fill="#344635"/>
+<rect x="10" y="25" width="1" height="1" fill="#82A35E"/>
+<rect x="11" y="25" width="1" height="1" fill="#82A35E"/>
+<rect x="12" y="25" width="1" height="1" fill="#82A35E"/>
+<rect x="26" y="25" width="1" height="1" fill="#82A35E"/>
+<rect x="27" y="25" width="1" height="1" fill="#82A35E"/>
+<rect x="28" y="25" width="1" height="1" fill="#82A35E"/>
+<rect x="29" y="25" width="1" height="1" fill="#82A35E"/>
+<rect x="30" y="25" width="1" height="1" fill="#82A35E"/>
+<rect x="31" y="25" width="1" height="1" fill="#82A35E"/>
+<rect x="32" y="25" width="1" height="1" fill="#82A35E"/>
+<rect x="10" y="26" width="1" height="1" fill="#A9C38D"/>
+<rect x="11" y="26" width="1" height="1" fill="#82A35E"/>
+<rect x="12" y="26" width="1" height="1" fill="#82A35E"/>
+<rect x="26" y="26" width="1" height="1" fill="#82A35E"/>
+<rect x="27" y="26" width="1" height="1" fill="#A9C38D"/>
+<rect x="28" y="26" width="1" height="1" fill="#A9C38D"/>
+<rect x="29" y="26" width="1" height="1" fill="#A9C38D"/>
+<rect x="30" y="26" width="1" height="1" fill="#82A35E"/>
+<rect x="31" y="26" width="1" height="1" fill="#82A35E"/>
+<rect x="32" y="26" width="1" height="1" fill="#D93333"/>
+<rect x="10" y="27" width="1" height="1" fill="#82A35E"/>
+<rect x="11" y="27" width="1" height="1" fill="#82A35E"/>
+<rect x="12" y="27" width="1" height="1" fill="#82A35E"/>
+<rect x="26" y="27" width="1" height="1" fill="#82A35E"/>
+<rect x="27" y="27" width="1" height="1" fill="#A9C38D"/>
+<rect x="28" y="27" width="1" height="1" fill="#A9C38D"/>
+<rect x="33" y="27" width="1" height="1" fill="#D93333"/>
+<rect x="10" y="28" width="1" height="1" fill="#A9C38D"/>
+<rect x="11" y="28" width="1" height="1" fill="#82A35E"/>
+<rect x="12" y="28" width="1" height="1" fill="#82A35E"/>
+<rect x="13" y="28" width="1" height="1" fill="#82A35E"/>
+<rect x="14" y="28" width="1" height="1" fill="#82A35E"/>
+<rect x="15" y="28" width="1" height="1" fill="#82A35E"/>
+<rect x="16" y="28" width="1" height="1" fill="#82A35E"/>
+<rect x="17" y="28" width="1" height="1" fill="#82A35E"/>
+<rect x="18" y="28" width="1" height="1" fill="#82A35E"/>
+<rect x="19" y="28" width="1" height="1" fill="#82A35E"/>
+<rect x="20" y="28" width="1" height="1" fill="#82A35E"/>
+<rect x="10" y="29" width="1" height="1" fill="#82A35E"/>
+<rect x="11" y="29" width="1" height="1" fill="#82A35E"/>
+<rect x="12" y="29" width="1" height="1" fill="#82A35E"/>
+<rect x="13" y="29" width="1" height="1" fill="#82A35E"/>
+<rect x="14" y="29" width="1" height="1" fill="#82A35E"/>
+<rect x="15" y="29" width="1" height="1" fill="#82A35E"/>
+<rect x="16" y="29" width="1" height="1" fill="#82A35E"/>
+<rect x="17" y="29" width="1" height="1" fill="#82A35E"/>
+<rect x="18" y="29" width="1" height="1" fill="#82A35E"/>
+<rect x="19" y="29" width="1" height="1" fill="#82A35E"/>
+<rect x="20" y="29" width="1" height="1" fill="#82A35E"/>
+<rect x="21" y="29" width="1" height="1" fill="#82A35E"/>
+<rect x="22" y="29" width="1" height="1" fill="#82A35E"/>
+<rect x="23" y="29" width="1" height="1" fill="#82A35E"/>
+<rect x="24" y="29" width="1" height="1" fill="#82A35E"/>
+<rect x="12" y="30" width="1" height="1" fill="#82A35E"/>
+<rect x="13" y="30" width="1" height="1" fill="#A9C38D"/>
+<rect x="14" y="30" width="1" height="1" fill="#82A35E"/>
+<rect x="15" y="30" width="1" height="1" fill="#A9C38D"/>
+<rect x="16" y="30" width="1" height="1" fill="#82A35E"/>
+<rect x="17" y="30" width="1" height="1" fill="#A9C38D"/>
+<rect x="18" y="30" width="1" height="1" fill="#82A35E"/>
+<rect x="19" y="30" width="1" height="1" fill="#A9C38D"/>
+<rect x="20" y="30" width="1" height="1" fill="#82A35E"/>
+<rect x="21" y="30" width="1" height="1" fill="#A9C38D"/>
+<rect x="22" y="30" width="1" height="1" fill="#82A35E"/>
+<rect x="23" y="30" width="1" height="1" fill="#A9C38D"/>
+<rect x="24" y="30" width="1" height="1" fill="#82A35E"/>
+<rect x="25" y="30" width="1" height="1" fill="#82A35E"/>
+<rect x="26" y="30" width="1" height="1" fill="#82A35E"/>
+<rect x="19" y="31" width="1" height="1" fill="#A9C38D"/>
+<rect x="20" y="31" width="1" height="1" fill="#82A35E"/>
+<rect x="21" y="31" width="1" height="1" fill="#A9C38D"/>
+<rect x="22" y="31" width="1" height="1" fill="#82A35E"/>
+<rect x="23" y="31" width="1" height="1" fill="#A9C38D"/>
+<rect x="24" y="31" width="1" height="1" fill="#82A35E"/>
+<rect x="25" y="31" width="1" height="1" fill="#A9C38D"/>
+<rect x="26" y="31" width="1" height="1" fill="#82A35E"/>
+<rect x="27" y="31" width="1" height="1" fill="#82A35E"/>
+<rect x="25" y="32" width="1" height="1" fill="#A9C38D"/>
+<rect x="26" y="32" width="1" height="1" fill="#82A35E"/>
+<rect x="27" y="32" width="1" height="1" fill="#82A35E"/>
+<rect x="28" y="32" width="1" height="1" fill="#82A35E"/>
+<rect x="27" y="33" width="1" height="1" fill="#A9C38D"/>
+<rect x="28" y="33" width="1" height="1" fill="#82A35E"/>
+<rect x="28" y="34" width="1" height="1" fill="#82A35E"/>
+<rect x="29" y="34" width="1" height="1" fill="#82A35E"/>
+<rect x="29" y="35" width="1" height="1" fill="#82A35E"/>
 </svg>
+
 
 
 </svg>


### PR DESCRIPTION
This update adds the path for the tamagotchi shape, updates the layout of all elements, and rips out what's no longer used. Still to do:
-  minor positioning adjustments
-  rewrite tamagotchi drop-shadow to accept different colors
-  refactor XP counters as reusable elements
<img width="503" alt="image" src="https://user-images.githubusercontent.com/971753/172846813-097aff3c-aadb-4524-9f6b-9cdea3536c20.png">
